### PR TITLE
fixed html-tree when passed "".

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject vdom "0.2.2-SNAPSHOT"
+(defproject vdom "0.2.3-SNAPSHOT"
   :description "Virtual-dom library"
   :url "https://github.com/exupero/vdom"
   :license {:name "MIT License"

--- a/src/vdom/core.cljs
+++ b/src/vdom/core.cljs
@@ -26,12 +26,17 @@
 
 (declare svg-tree)
 
+(defn virtual-node? [arg]
+  ;; use javascript notion of true/false,
+  ;; otherwise, this will return true for "" and cause issues
+  (js/Boolean (js/VDOM.isVirtualNode arg)))
+
 (defn html-tree [arg]
   (cond
     (nil? arg)
     (text-node "")
 
-    (js/VDOM.isVirtualNode arg)
+    (virtual-node? arg)
     arg
 
     (seq? arg)
@@ -55,7 +60,7 @@
     (nil? arg)
     (text-node "")
 
-    (js/VDOM.isVirtualNode arg)
+    (virtual-node? arg)
     arg
 
     (string? arg)

--- a/src/vdom/core.cljs
+++ b/src/vdom/core.cljs
@@ -27,8 +27,12 @@
 (declare svg-tree)
 
 (defn virtual-node? [arg]
-  ;; use javascript notion of true/false,
-  ;; otherwise, this will return true for "" and cause issues
+  ;; Use javascript notion of true/false.
+  ;; `js/VDOM.isVirtualNode` doesn't just return true/false, but will
+  ;; return any js falsey argument passed in unchanged (eg. "").
+  ;; This causes `js/VDOM.isVirtualNode` to be false in js
+  ;; and true in cljs for any value that is falsey in js and
+  ;; true in cljs (eg. "", 0, -0, NaN, 0n).
   (js/Boolean (js/VDOM.isVirtualNode arg)))
 
 (defn html-tree [arg]


### PR DESCRIPTION
`html-tree` should return a VText("") node when passed "", but it returns "".

Below is an example of how this can cause issues:

```
(let [render (vdom.core/renderer js/document.body)]
  (render [:div {} "Hello, world"])
  (js/setTimeout (fn []
                   (render [:div {} ""]))
                 5000))
```

This should add a div that says "Hello World" and then change the div's text to "" after 5 seconds, but it does not. Instead, the text remains unchanged as "Hello World"